### PR TITLE
Change js lambda to function for improved compatibility with older browsers

### DIFF
--- a/webrtcstreamer.js
+++ b/webrtcstreamer.js
@@ -239,7 +239,7 @@ WebRtcStreamer.prototype.onAddStream = function(event) {
 	videoElement.srcObject = event.stream;
 	var promise = videoElement.play();
 	if (promise !== undefined) {
-	  promise.catch(error => {
+	  promise.catch(function(error) {
 		console.warn("error:"+error);
 		videoElement.setAttribute("controls", true);
 	  });


### PR DESCRIPTION
This change lets the js file compile on older systems. 

While older systems don't use webrtc, if this code is concattenated into other js files using grunt/webpack, the "syntax error" will prevent the rest of the .js file to load.